### PR TITLE
존재하지 않는 이메일로 로그인 버그

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -160,7 +160,25 @@ describe('AuthService', () => {
       expect(user).toEqual(RESULT_USER);
     });
 
-    it('이메일 비밀번호가 맞지 않다면 null 반환', async () => {
+    it('존재하지 않는 이메일이면 UnauthorizedException 발생', async () => {
+      // given
+      const authService = new AuthService(
+        tokenService,
+        new UserRepositoryStub(userList),
+        new JwtTokenRepositoryStub(jwtTokenList),
+      );
+
+      const email = 'invalid@email.com';
+      const password = 'invalid password';
+
+      // when
+      // then
+      await expect(
+        authService.validateLocalUser(email, password),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('비밀번호가 맞지 않다면 UnauthorizedException 발생', async () => {
       // given
       const authService = new AuthService(
         tokenService,
@@ -172,10 +190,10 @@ describe('AuthService', () => {
       const password = 'invalid password';
 
       // when
-      const result = await authService.validateLocalUser(email, password);
-
       // then
-      expect(result).toBeNull();
+      await expect(
+        authService.validateLocalUser(email, password),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -56,8 +56,16 @@ export class AuthService {
 
   async validateLocalUser(email: string, password: string): Promise<User> {
     const user = await this.userRepository.findOneByEmail(email);
+    if (!user) {
+      throw new UnauthorizedException(ErrorMessage.LOGIN_FAILED);
+    }
+
     const encryptedPassword = EncryptedPassword.from(user.password);
-    return encryptedPassword.equals(password) ? user : null;
+    if (!encryptedPassword.equals(password)) {
+      throw new UnauthorizedException(ErrorMessage.LOGIN_FAILED);
+    }
+
+    return user;
   }
 
   async jwtSign(userPayload: UserPayloadDto): Promise<JwtToken> {

--- a/src/auth/strategy/local.strategy.ts
+++ b/src/auth/strategy/local.strategy.ts
@@ -1,11 +1,10 @@
-import { UserPayloadDto } from './../dto/user-payload.dto';
+import { UserPayloadDto } from '../dto/user-payload.dto';
 import { Strategy } from 'passport-local';
 
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 
 import { AuthService } from '../auth.service';
-import { ErrorMessage } from '../enum/error-message.enum';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -17,9 +16,6 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
 
   async validate(email: string, password: string): Promise<UserPayloadDto> {
     const user = await this.authService.validateLocalUser(email, password);
-    if (!user) {
-      throw new UnauthorizedException(ErrorMessage.LOGIN_FAILED);
-    }
     return UserPayloadDto.from(user);
   }
 }


### PR DESCRIPTION
# Task Summary
- 존재하지 않는 이메일로 로그인 시 500 에러가 발생하는 문제 해결

# Description
- 로그인 로직에서 회원 조회 로직 과정에 에러 핸들 추가
- AuthService에서 직접 에러를 throw 하도록 수정