### PR TITLE
37 auth 관련 엔티티 설계 개선

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -22,11 +22,9 @@ import {
   when,
 } from '@johanblumenberg/ts-mockito';
 import {
-  createOauthUser,
   createUser,
   EMAIL,
   NICKNAME,
-  PROVIDER_ID,
   PROVIDER_TYPE,
   USER_ID,
 } from '../test/dummies/user.dummy';
@@ -36,7 +34,6 @@ import {
   REFRESH_TOKEN,
 } from '../test/dummies/jwt-token.dummy';
 import { createUserPayloadDto } from '../test/dummies/user-payload.dummy';
-import { OauthPayloadDto } from './dto/oauth-payload.dto';
 
 describe('AuthController', () => {
   const getTestingModule = (userService: IAuthService) =>
@@ -125,12 +122,12 @@ describe('AuthController', () => {
       authController = module.get<AuthController>(AuthController);
     });
 
-    it('user payload로 로그인하면 jwt token 관련 정보를 반환', async () => {
+    it('user로 로그인하면 jwt token 관련 정보를 반환', async () => {
       // given
-      const userPayloadDto = createUserPayloadDto({});
+      const user = createUser({});
 
       // when
-      const jwtSignResultDto = await authController.login(userPayloadDto);
+      const jwtSignResultDto = await authController.login(user);
 
       // then
       expect(jwtSignResultDto.userId).toEqual(USER_ID);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -44,8 +44,7 @@ import { SignupBadrequestResponseDto } from './dto/error/signup-badrequest-respo
 import { AuthErrorMessage } from './auth.error-message';
 import { IAuthService } from './auth.service.interface';
 import { JwtUnauthorizedResponseDto } from '../common/dto/jwt-unauthorized-response.dto';
-import { GoogleAuthGuard } from './guards/google-auth.guard';
-import { OauthPayloadDto } from './dto/oauth-payload.dto';
+import { User } from '../user/entities/user.entity';
 
 @ApiTags('auth')
 @Controller('api/auth')
@@ -96,10 +95,8 @@ export class AuthController {
   })
   @UseGuards(LocalAuthGuard)
   @UseInterceptors(SetRTCookieInterceptor)
-  async login(
-    @RequestUser() userPayload: UserPayloadDto,
-  ): Promise<JwtSignResultDto> {
-    const jwtToken = await this.authService.jwtSign(userPayload);
+  async login(@RequestUser() user: User): Promise<JwtSignResultDto> {
+    const jwtToken = await this.authService.jwtSign(user);
     return JwtSignResultDto.fromJwtToken(jwtToken);
   }
 

--- a/src/auth/auth.service.interface.ts
+++ b/src/auth/auth.service.interface.ts
@@ -1,6 +1,5 @@
 import { LocalSignupRequestDto } from './dto/request/local-signup-request.dto';
 import { User } from '../user/entities/user.entity';
-import { UserPayloadDto } from './dto/user-payload.dto';
 import { JwtToken } from './entity/jwt-token.entity';
 import { OauthPayloadDto } from './dto/oauth-payload.dto';
 
@@ -11,7 +10,7 @@ export interface IAuthService {
 
   validateOrSignupOauthUser(oauthPayload: OauthPayloadDto): Promise<User>;
 
-  jwtSign(userPayload: UserPayloadDto): Promise<JwtToken>;
+  jwtSign(user: User): Promise<JwtToken>;
 
   rotateRefreshToken(
     prevRefreshToken: string,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -5,7 +5,6 @@ import { User } from 'src/user/entities/user.entity';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { createJwtOptions } from './auth.config';
-import { UserPayloadDto } from './dto/user-payload.dto';
 import { JwtToken } from './entity/jwt-token.entity';
 import { UserRepositoryStub } from 'src/test/stub/user.repository.stub';
 import {
@@ -322,7 +321,7 @@ describe('AuthService', () => {
       const nickname = NICKNAME;
       const providerType = OauthProvider.LOCAL;
 
-      const userPayload = UserPayloadDto.create({
+      const user = User.create({
         id: userId,
         email,
         nickname,
@@ -330,7 +329,7 @@ describe('AuthService', () => {
       });
 
       // when
-      const jwtToken = await authService.jwtSign(userPayload);
+      const jwtToken = await authService.jwtSign(user);
 
       // then
       expect(jwtToken).toBeInstanceOf(JwtToken);
@@ -359,7 +358,7 @@ describe('AuthService', () => {
       const nickname = NICKNAME;
       const providerType = OauthProvider.LOCAL;
 
-      const userPayload = UserPayloadDto.create({
+      const user = User.create({
         id: userId,
         email,
         nickname,
@@ -367,7 +366,7 @@ describe('AuthService', () => {
       });
 
       // when
-      const jwtToken = await authService.jwtSign(userPayload);
+      const jwtToken = await authService.jwtSign(user);
 
       // then
       expect(jwtToken).toBeInstanceOf(JwtToken);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,7 +11,6 @@ import {
 import { User } from 'src/user/entities/user.entity';
 
 import { LocalSignupRequestDto } from './dto/request/local-signup-request.dto';
-import { UserPayloadDto } from './dto/user-payload.dto';
 import { TokenService } from './token.service';
 import { IUserRepository } from 'src/user/repository/user.repository.interface';
 import { IJwtTokenRepository } from './repository/jwt-token.repository.interface';
@@ -94,8 +93,8 @@ export class AuthServiceImpl implements IAuthService {
     return await this.userRepository.save(user);
   }
 
-  async jwtSign(userPayload: UserPayloadDto): Promise<JwtToken> {
-    const userId = userPayload.id;
+  async jwtSign(user: User): Promise<JwtToken> {
+    const userId = user.id;
 
     const accessToken = this.tokenService.generateAccessToken(userId);
     const refreshToken = this.tokenService.generateRefreshToken(userId);
@@ -105,7 +104,7 @@ export class AuthServiceImpl implements IAuthService {
 
     const newToken = JwtToken.create({
       ...(existsToken && { id: tokenId }),
-      userId,
+      user,
       accessToken,
       refreshToken,
       expiresAt: this.tokenService.getRefreshTokenExpiresAt(),

--- a/src/auth/entity/jwt-token.entity.spec.ts
+++ b/src/auth/entity/jwt-token.entity.spec.ts
@@ -1,19 +1,7 @@
-import { JwtToken } from './jwt-token.entity';
+import { createJwtToken } from '../../test/dummies/jwt-token.dummy';
 
 describe('JwtToken', () => {
   describe('equalsAccessToken', () => {
-    const createJwtToken = ({
-      accessToken = '',
-      refreshToken = '',
-      expiresAt = new Date(),
-      userId = 1,
-    }) =>
-      JwtToken.create({
-        accessToken,
-        refreshToken,
-        expiresAt,
-        userId,
-      });
     it('동일한 access token으로 호출하면 true를 반환', () => {
       // given
       const accessToken = 'valid access token';

--- a/src/auth/entity/jwt-token.entity.ts
+++ b/src/auth/entity/jwt-token.entity.ts
@@ -14,15 +14,15 @@ export class JwtToken {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ unique: true, nullable: false })
+  @Column({ unique: true })
   @IsNotEmpty()
   accessToken: string;
 
-  @Column({ unique: true, nullable: false })
+  @Column({ unique: true })
   @IsNotEmpty()
   refreshToken: string;
 
-  @Column({ type: 'datetime', nullable: false })
+  @Column({ type: 'datetime' })
   @IsNotEmpty()
   expiresAt: Date;
 
@@ -31,7 +31,7 @@ export class JwtToken {
     nullable: false,
   })
   @JoinColumn()
-  user!: User;
+  user: User;
 
   @Column({ nullable: false })
   @IsNumber()
@@ -45,13 +45,14 @@ export class JwtToken {
     user: User,
     id?: number,
   ) {
+    if (id) {
+      this.id = id;
+    }
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.expiresAt = expiresAt;
     this.user = user;
-    if (id) {
-      this.id = id;
-    }
+    this.userId = user?.id;
   }
 
   static create({

--- a/src/auth/entity/jwt-token.entity.ts
+++ b/src/auth/entity/jwt-token.entity.ts
@@ -6,12 +6,13 @@ import {
   PrimaryGeneratedColumn,
   OneToOne,
   JoinColumn,
+  RelationId,
 } from 'typeorm';
 
 @Entity()
 export class JwtToken {
   @PrimaryGeneratedColumn()
-  id?: number;
+  id!: number;
 
   @Column({ unique: true, nullable: false })
   @IsNotEmpty()
@@ -25,29 +26,32 @@ export class JwtToken {
   @IsNotEmpty()
   expiresAt: Date;
 
-  @OneToOne(() => User, (user) => user.jwtToken, {
+  @OneToOne(() => User, {
     onDelete: 'CASCADE',
     nullable: false,
   })
   @JoinColumn()
-  user?: User;
+  user!: User;
 
-  @Column({ nullable: false, unique: true })
+  @Column({ nullable: false })
   @IsNumber()
-  userId: number;
+  @RelationId((jwtToken: JwtToken) => jwtToken.user)
+  userId!: number;
 
   private constructor(
     accessToken: string,
     refreshToken: string,
     expiresAt: Date,
-    userId: number,
+    user: User,
     id?: number,
   ) {
-    this.id = id;
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.expiresAt = expiresAt;
-    this.userId = userId;
+    this.user = user;
+    if (id) {
+      this.id = id;
+    }
   }
 
   static create({
@@ -55,15 +59,15 @@ export class JwtToken {
     accessToken,
     refreshToken,
     expiresAt,
-    userId,
+    user,
   }: {
     id?: number;
     accessToken: string;
     refreshToken: string;
     expiresAt: Date;
-    userId: number;
+    user: User;
   }): JwtToken {
-    return new JwtToken(accessToken, refreshToken, expiresAt, userId, id);
+    return new JwtToken(accessToken, refreshToken, expiresAt, user, id);
   }
 
   clone(): JwtToken {
@@ -71,7 +75,7 @@ export class JwtToken {
       this.accessToken,
       this.refreshToken,
       this.expiresAt,
-      this.userId,
+      this.user,
       this.id,
     );
   }

--- a/src/auth/oauth.controller.spec.ts
+++ b/src/auth/oauth.controller.spec.ts
@@ -2,7 +2,6 @@ import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { IAuthService } from './auth.service.interface';
 import { AuthServiceStub } from '../test/stub/auth.service.stub';
-import { AuthController } from './auth.controller';
 import { OauthProvider } from '../common/enums/oauth-provider.enum';
 import { UnauthorizedException } from '@nestjs/common';
 import { AuthErrorMessage } from './auth.error-message';
@@ -18,7 +17,7 @@ import { createJwtToken } from '../test/dummies/jwt-token.dummy';
 import { OauthPayloadDto } from './dto/oauth-payload.dto';
 import { OauthController } from './oauth.controller';
 
-describe('AuthController', () => {
+describe('OauthController', () => {
   const getTestingModule = (userService: IAuthService) =>
     Test.createTestingModule({
       imports: [

--- a/src/auth/oauth.controller.ts
+++ b/src/auth/oauth.controller.ts
@@ -62,7 +62,7 @@ export class OauthController {
     @RequestUser() oauthPayload: OauthPayloadDto,
   ): Promise<JwtSignResultDto> {
     const user = await this.authService.validateOrSignupOauthUser(oauthPayload);
-    const jwtToken = await this.authService.jwtSign(UserPayloadDto.from(user));
+    const jwtToken = await this.authService.jwtSign(user);
     return JwtSignResultDto.fromJwtToken(jwtToken);
   }
 
@@ -94,7 +94,7 @@ export class OauthController {
     @RequestUser() oauthPayload: OauthPayloadDto,
   ): Promise<JwtSignResultDto> {
     const user = await this.authService.validateOrSignupOauthUser(oauthPayload);
-    const jwtToken = await this.authService.jwtSign(UserPayloadDto.from(user));
+    const jwtToken = await this.authService.jwtSign(user);
     return JwtSignResultDto.fromJwtToken(jwtToken);
   }
 }

--- a/src/auth/strategy/local.strategy.spec.ts
+++ b/src/auth/strategy/local.strategy.spec.ts
@@ -12,11 +12,11 @@ import {
   PASSWORD,
   USER_ID,
 } from '../../test/dummies/user.dummy';
-import { UserPayloadDto } from '../dto/user-payload.dto';
 import { OauthProvider } from '../../common/enums/oauth-provider.enum';
 import { UnauthorizedException } from '@nestjs/common';
 import { AuthErrorMessage } from '../auth.error-message';
 import { createJwtToken } from '../../test/dummies/jwt-token.dummy';
+import { User } from '../../user/entities/user.entity';
 
 describe('LocalStrategy', () => {
   let localStrategy: LocalStrategy;
@@ -57,9 +57,10 @@ describe('LocalStrategy', () => {
 
       // then
       expect(result).toEqual(
-        UserPayloadDto.create({
+        User.create({
           id: USER_ID,
           email: EMAIL,
+          password: ENCRYPTED_PASSWORD.getPassword(),
           nickname: NICKNAME,
           providerType: OauthProvider.LOCAL,
         }),

--- a/src/auth/strategy/local.strategy.ts
+++ b/src/auth/strategy/local.strategy.ts
@@ -1,10 +1,10 @@
-import { UserPayloadDto } from '../dto/user-payload.dto';
 import { Strategy } from 'passport-local';
 
 import { Inject, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 
 import { IAuthService } from '../auth.service.interface';
+import { User } from '../../user/entities/user.entity';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -17,8 +17,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(email: string, password: string): Promise<UserPayloadDto> {
-    const user = await this.authService.validateLocalUser(email, password);
-    return UserPayloadDto.from(user);
+  async validate(email: string, password: string): Promise<User> {
+    return await this.authService.validateLocalUser(email, password);
   }
 }

--- a/src/test/dummies/jwt-token.dummy.ts
+++ b/src/test/dummies/jwt-token.dummy.ts
@@ -1,4 +1,4 @@
-import { USER_ID } from './user.dummy';
+import { createUser } from './user.dummy';
 import { JwtToken } from '../../auth/entity/jwt-token.entity';
 
 export const TOKEN_ID = 1;
@@ -8,9 +8,9 @@ export const REFRESH_TOKEN = 'valid_refresh_token';
 
 export const createJwtToken = ({
   id = TOKEN_ID,
-  userId = USER_ID,
+  user = createUser({}),
   accessToken = ACCESS_TOKEN,
   refreshToken = REFRESH_TOKEN,
   expiresAt = new Date(),
 }: Partial<JwtToken>) =>
-  JwtToken.create({ id, userId, accessToken, refreshToken, expiresAt });
+  JwtToken.create({ id, user, accessToken, refreshToken, expiresAt });

--- a/src/test/stub/auth.service.stub.ts
+++ b/src/test/stub/auth.service.stub.ts
@@ -1,8 +1,6 @@
-// implements IAuthService
+import { JwtToken } from 'src/auth/entity/jwt-token.entity';
 
 import { IAuthService } from '../../auth/auth.service.interface';
-import { UserPayloadDto } from '../../auth/dto/user-payload.dto';
-import { JwtToken } from '../../auth/entity/jwt-token.entity';
 import { LocalSignupRequestDto } from '../../auth/dto/request/local-signup-request.dto';
 import { User } from '../../user/entities/user.entity';
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
@@ -54,13 +52,13 @@ export class AuthServiceStub implements IAuthService {
     );
   }
 
-  jwtSign(userPayload: UserPayloadDto): Promise<JwtToken> {
+  jwtSign(user: User): Promise<JwtToken> {
     return Promise.resolve(
       JwtToken.create({
         accessToken: 'accessToken',
         refreshToken: 'refreshToken',
         expiresAt: new Date(new Date().getTime() + 1000),
-        userId: userPayload.id,
+        user,
       }),
     );
   }
@@ -83,7 +81,7 @@ export class AuthServiceStub implements IAuthService {
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
         expiresAt: new Date(new Date().getTime() + 1000),
-        userId: this.existingJwtToken.userId,
+        user: this.existingJwtToken.user,
       }),
     );
   }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -29,7 +29,7 @@ export class User {
   @IsUserEmail()
   email: string;
 
-  @Column()
+  @Column({ nullable: true })
   @IsBcryptEncrypted()
   password?: string;
 
@@ -40,7 +40,7 @@ export class User {
   @Column({ type: 'enum', enum: OauthProvider, default: OauthProvider.LOCAL })
   providerType: OauthProvider;
 
-  @Column()
+  @Column({ nullable: true })
   @IsString()
   providerId?: string;
 

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,4 @@
 import { IsString } from 'class-validator';
-import { JwtToken } from '../../auth/entity/jwt-token.entity';
 import { OauthProvider } from '../../common/enums/oauth-provider.enum';
 import {
   Entity,
@@ -7,8 +6,6 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
-  OneToOne,
-  JoinColumn,
 } from 'typeorm';
 
 import {
@@ -20,7 +17,7 @@ import {
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  id?: number;
+  id!: number;
 
   @CreateDateColumn()
   createdAt?: Date;
@@ -47,10 +44,6 @@ export class User {
   @IsString()
   providerId?: string;
 
-  @OneToOne(() => JwtToken, (jwtToken) => jwtToken.user)
-  @JoinColumn()
-  jwtToken?: JwtToken;
-
   private constructor(
     email: string,
     nickname: string,
@@ -61,7 +54,9 @@ export class User {
     createdAt?: Date,
     updatedAt?: Date,
   ) {
-    this.id = id;
+    if (id) {
+      this.id = id;
+    }
     this.email = email;
     this.password = password;
     this.nickname = nickname;


### PR DESCRIPTION
## Task Summary
- Auth 관련 엔티티(User, JwtToken)의 설계를 개선하고, 관련 API를 일부 수정합니다.

## Description
- User, JwtToken의 OneToOne 관계 부분을 개선합니다
  - User에서 JwtToken을 참조할 일이 없으므로, 단방향 관계로 수정합니다
  - JwtToken에서 외래키(userId) 자체가 아닌 User 객체와의 객체 관계를 통해 엔티티 관계를 형성하도록 수정합니다
- 위 설계를 위해 jwtSign 메서드가 User 객체 자체를 반환하도록 수정합니다
- 테스트 코드를 위 설계에 맞게 변경하고, 일부 개선합니다.
