### PR TITLE
JWT 토큰 관련 쿠키 유효 시간 연장

### DIFF
--- a/src/auth/interceptors/set-jwt-token-cookie.interceptor.ts
+++ b/src/auth/interceptors/set-jwt-token-cookie.interceptor.ts
@@ -24,11 +24,13 @@ export class SetJWTTokenCookieInterceptor implements NestInterceptor {
         const loginResponse = LoginResponseDto.fromJwtSignResult(jwtSignResult);
         res.cookie('refresh_token', jwtSignResult.refreshToken, {
           httpOnly: true,
-          maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME'),
+          maxAge:
+            +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
         });
         res.cookie('access_token', jwtSignResult.accessToken, {
           httpOnly: true,
-          maxAge: +this.configService.get('JWT_ACCESS_TOKEN_EXPIRATION_TIME'),
+          maxAge:
+            +this.configService.get('JWT_ACCESS_TOKEN_EXPIRATION_TIME') * 1000,
         });
         return loginResponse;
       }),


### PR DESCRIPTION
## Task Summary
- jwt 토큰 쿠키의 유효시간이 짧게 설정되는 버그를 고칩니다.

## Description
- 시간 단위를 다르게 변경하여 적용합니다